### PR TITLE
Use exponential backoff

### DIFF
--- a/update_calendar.py
+++ b/update_calendar.py
@@ -50,9 +50,7 @@ def clear_dev_calendar(calendar_events, config):
 
     for holiday in old_dev_holidays:
         execute_or_exponential_backoff(
-            calendar_events.delete,
-            calendarId=config['calendar_ids']['dev'],
-            eventId=holiday['id']
+            calendar_events.delete(calendarId=config['calendar_ids']['dev'], eventId=holiday['id'])
         )
 
 
@@ -75,9 +73,7 @@ def add_dev_holidays(calendar_events, config):
 
     for holiday in dev_holidays:
         execute_or_exponential_backoff(
-            calendar_events.insert,
-            calendarId=config['calendar_ids']['dev'],
-            body=holiday
+            calendar_events.insert(calendarId=config['calendar_ids']['dev'], body=holiday)
         )
 
 
@@ -88,10 +84,7 @@ def get_calendar_events(calendar_events, calendar_id):
     page_token = None
     while True:
         page_events = execute_or_exponential_backoff(
-            calendar_events.list,
-            calendarId=calendar_id,
-            pageToken=page_token,
-            timeMin=start_time
+            calendar_events.list(calendarId=calendar_id, pageToken=page_token, timeMin=start_time)
         )
         events += page_events['items']
         page_token = page_events.get('nextPageToken')
@@ -100,10 +93,10 @@ def get_calendar_events(calendar_events, calendar_id):
     return events
 
 
-def execute_or_exponential_backoff(func, max_attempts=8, **kwargs):
+def execute_or_exponential_backoff(http_request, max_attempts=8):
     for i in range(max_attempts):
         try:
-            return func(**kwargs).execute()
+            return http_request.execute()
         except HttpError:
             if i < max_attempts - 1:
                 print(f'sleeping for {2 ** i} seconds.')

--- a/update_calendar.py
+++ b/update_calendar.py
@@ -97,12 +97,15 @@ def execute_or_exponential_backoff(http_request, max_sleep_seconds=64, max_attem
     for i in range(max_attempts):
         try:
             return http_request.execute()
-        except HttpError:
-            if i < max_attempts - 1:
+        except HttpError as e:
+            is_4xx_status = 399 < e.resp.status < 500
+            attempts_remaining = i < max_attempts - 1
+
+            if is_4xx_status and attempts_remaining:
                 sleep(min(2 ** i, max_sleep_seconds))
                 continue
-            else:
-                raise
+
+            raise
 
 
 def main():

--- a/update_calendar.py
+++ b/update_calendar.py
@@ -99,9 +99,9 @@ def execute_or_exponential_backoff(http_request, max_sleep_seconds=64, max_attem
             return http_request.execute()
         except HttpError as e:
             is_4xx_status = 399 < e.resp.status < 500
-            attempts_remaining = i < max_attempts - 1
+            are_attempts_remaining = i < max_attempts - 1
 
-            if is_4xx_status and attempts_remaining:
+            if is_4xx_status and are_attempts_remaining:
                 sleep(min(2 ** i, max_sleep_seconds))
                 continue
 

--- a/update_calendar.py
+++ b/update_calendar.py
@@ -93,14 +93,13 @@ def get_calendar_events(calendar_events, calendar_id):
     return events
 
 
-def execute_or_exponential_backoff(http_request, max_attempts=8):
+def execute_or_exponential_backoff(http_request, max_sleep_seconds=64, max_attempts=10):
     for i in range(max_attempts):
         try:
             return http_request.execute()
         except HttpError:
             if i < max_attempts - 1:
-                print(f'sleeping for {2 ** i} seconds.')
-                sleep(2 ** i)
+                sleep(min(2 ** i, max_sleep_seconds))
                 continue
             else:
                 raise


### PR DESCRIPTION
The script was making too many requests and was constantly being stopped with rate limit errors. One suggestion was to use exponential backoff.

https://cloud.google.com/iot/docs/how-tos/exponential-backoff

Every time a HttpRequest fails then delay a little longer each time and make the request again.